### PR TITLE
Add cython to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cython <= 0.28.5
 transformers==4.6.0
 PyYAML==5.3.*
 pandas


### PR DESCRIPTION
While installing requirements.txt, I go the following error:
```
    Partial import of sklearn during the build process.
    Traceback (most recent call last):
      File "/tmp/pip-build-tp3hmn_9/scikit-learn/sklearn/_build_utils/__init__.py", line 27, in _check_cython_version
        import Cython
    ModuleNotFoundError: No module named 'Cython'
    
    The above exception was the direct cause of the following exception:
    
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-tp3hmn_9/scikit-learn/setup.py", line 306, in <module>
        setup_package()
      File "/tmp/pip-build-tp3hmn_9/scikit-learn/setup.py", line 302, in setup_package
        setup(**metadata)
      File "/data/mt/tasks/ika/ika-env/lib/python3.6/site-packages/numpy/distutils/core.py", line 135, in setup
        config = configuration()
      File "/tmp/pip-build-tp3hmn_9/scikit-learn/setup.py", line 186, in configuration
        _check_cython_version()
      File "/tmp/pip-build-tp3hmn_9/scikit-learn/sklearn/_build_utils/__init__.py", line 30, in _check_cython_version
        raise ModuleNotFoundError(message) from e
    ModuleNotFoundError: Please install Cython with a version >= 0.28.5 in order to build a scikit-learn from source
```

 
To solve this, I added `cython <= 0.28.5` to requirements.txt. 